### PR TITLE
Python2 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def long_description():
 
 setup(
     name='baluhn',
-    version='0.1.1',
+    version='0.1.2',
     license='Public Domain',
     description='A base-agnostic implementation of the Luhn Algorithm for '
         'Python. Useful for generating and verifying check digits.',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 def long_description():
     this_directory = path.abspath(path.dirname(__file__))
-    with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+    with open(path.join(this_directory, 'README.md')) as f:
         return f.read()
 
 


### PR DESCRIPTION
The code for reading the README as `long_description` didn't work in Python2. That's what you get for not running automated tests, I guess.